### PR TITLE
Fixed-width types in rpc_message_t + round-trip tests

### DIFF
--- a/include/rpc.h
+++ b/include/rpc.h
@@ -11,7 +11,6 @@ extern "C" {
 
 #include "utf/string.h"
 
-typedef struct rps_s rpc_t;
 typedef struct rpc_message_s rpc_message_t;
 
 enum {
@@ -39,18 +38,18 @@ enum {
 };
 
 struct rpc_message_s {
-  uintmax_t type;
-  uintmax_t id;
+  uint64_t type;
+  uint64_t id;
 
   union {
     // For `rpc_request`
-    uintmax_t command;
+    uint64_t command;
 
     // For `rpc_response`
     bool error;
   };
 
-  uintmax_t stream;
+  uint64_t stream;
 
   union {
     // For:
@@ -68,7 +67,7 @@ struct rpc_message_s {
     struct {
       utf8_string_view_t message;
       utf8_string_view_t code;
-      intmax_t status;
+      int64_t status;
     };
   };
 };

--- a/src/rpc.c
+++ b/src/rpc.c
@@ -211,7 +211,7 @@ rpc_encode_message (compact_state_t *state, const rpc_message_t *message) {
 }
 
 static inline int
-rpc_decode__request (compact_state_t *state, uintmax_t id, rpc_message_t *result) {
+rpc_decode__request (compact_state_t *state, uint64_t id, rpc_message_t *result) {
   int err;
 
   rpc_message_t request = {rpc_request, id};
@@ -233,7 +233,7 @@ rpc_decode__request (compact_state_t *state, uintmax_t id, rpc_message_t *result
 }
 
 static inline int
-rpc_decode__response (compact_state_t *state, uintmax_t id, rpc_message_t *result) {
+rpc_decode__response (compact_state_t *state, uint64_t id, rpc_message_t *result) {
   int err;
 
   rpc_message_t response = {rpc_response, id};
@@ -264,7 +264,7 @@ rpc_decode__response (compact_state_t *state, uintmax_t id, rpc_message_t *resul
 }
 
 static inline int
-rpc_decode__stream (compact_state_t *state, uintmax_t id, rpc_message_t *result) {
+rpc_decode__stream (compact_state_t *state, uint64_t id, rpc_message_t *result) {
   int err;
 
   rpc_message_t response = {rpc_response, id};
@@ -304,11 +304,11 @@ rpc_decode_message (compact_state_t *state, rpc_message_t *result) {
 
   if (state->end - state->start < frame) return rpc_partial;
 
-  uintmax_t type;
+  uint64_t type;
   err = compact_decode_uint(state, &type);
   if (err < 0) return rpc_error;
 
-  uintmax_t id;
+  uint64_t id;
   err = compact_decode_uint(state, &id);
   if (err < 0) return rpc_error;
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,1 +1,20 @@
+list(APPEND tests
+  message
+)
 
+foreach(test IN LISTS tests)
+  add_executable(${test} ${test}.c)
+
+  target_link_libraries(
+    ${test}
+    PRIVATE
+      rpc
+      compact
+      utf
+  )
+
+  add_test(
+    NAME ${test}
+    COMMAND ${test}
+  )
+endforeach()

--- a/test/message.c
+++ b/test/message.c
@@ -1,0 +1,74 @@
+#include <assert.h>
+#include <compact.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "../include/rpc.h"
+
+static void
+test_request(void) {
+  uint8_t payload[] = {1, 2, 3};
+
+  rpc_message_t msg = {0};
+  msg.type = rpc_request;
+  msg.id = 7;
+  msg.command = 42;
+  msg.stream = 0;
+  msg.data = payload;
+  msg.len = sizeof(payload);
+
+  compact_state_t enc = {0, 0, NULL};
+  assert(rpc_preencode_message(&enc, &msg) == 0);
+  enc.buffer = malloc(enc.end);
+  assert(rpc_encode_message(&enc, &msg) == 0);
+
+  compact_state_t dec = {0, enc.end, enc.buffer};
+  rpc_message_t out = {0};
+  assert(rpc_decode_message(&dec, &out) == 0);
+
+  assert(out.type == rpc_request);
+  assert(out.id == 7);
+  assert(out.command == 42);
+  assert(out.stream == 0);
+  assert(out.len == sizeof(payload));
+  assert(memcmp(out.data, payload, sizeof(payload)) == 0);
+
+  free(enc.buffer);
+}
+
+static void
+test_response(void) {
+  uint8_t payload[] = {9, 8};
+
+  rpc_message_t msg = {0};
+  msg.type = rpc_response;
+  msg.id = 7;
+  msg.error = false;
+  msg.stream = 0;
+  msg.data = payload;
+  msg.len = sizeof(payload);
+
+  compact_state_t enc = {0, 0, NULL};
+  assert(rpc_preencode_message(&enc, &msg) == 0);
+  enc.buffer = malloc(enc.end);
+  assert(rpc_encode_message(&enc, &msg) == 0);
+
+  compact_state_t dec = {0, enc.end, enc.buffer};
+  rpc_message_t out = {0};
+  assert(rpc_decode_message(&dec, &out) == 0);
+
+  assert(out.type == rpc_response);
+  assert(out.id == 7);
+  assert(out.error == false);
+  assert(out.len == sizeof(payload));
+  assert(memcmp(out.data, payload, sizeof(payload)) == 0);
+
+  free(enc.buffer);
+}
+
+int
+main(void) {
+  test_request();
+  test_response();
+  return 0;
+}


### PR DESCRIPTION
rpc_message_t used uintmax_t/intmax_t while libcompact decoders take uint64_t*/int64_t*, producing incompatible-pointer warnings and UB where widths differ. Switches to fixed-width types and adds request/response round-trip tests. Removes the dead rpc_t typedef.

The rpc_decode__stream double-decode bug is tracked separately and fixed before hrpc-c streaming codegen (PR B).