### PR TITLE
Fix rpc_stream decoding (type + double-decode)

### DIFF
--- a/src/rpc.c
+++ b/src/rpc.c
@@ -267,29 +267,26 @@ static inline int
 rpc_decode__stream (compact_state_t *state, uint64_t id, rpc_message_t *result) {
   int err;
 
-  rpc_message_t response = {rpc_response, id};
+  rpc_message_t stream = {rpc_stream, id};
 
-  err = compact_decode_uint(state, &response.stream);
+  err = compact_decode_uint(state, &stream.stream);
   if (err < 0) return rpc_error;
 
-  err = compact_decode_uint(state, &response.stream);
-  if (err < 0) return rpc_error;
-
-  if (response.stream & rpc_stream_error) {
-    err = compact_decode_utf8(state, &response.message);
+  if (stream.stream & rpc_stream_error) {
+    err = compact_decode_utf8(state, &stream.message);
     if (err < 0) return rpc_error;
 
-    err = compact_decode_utf8(state, &response.code);
+    err = compact_decode_utf8(state, &stream.code);
     if (err < 0) return rpc_error;
 
-    err = compact_decode_int(state, &response.status);
+    err = compact_decode_int(state, &stream.status);
     if (err < 0) return rpc_error;
-  } else if (response.stream & rpc_stream_data) {
-    err = compact_decode_uint8array(state, &response.data, &response.len);
+  } else if (stream.stream & rpc_stream_data) {
+    err = compact_decode_uint8array(state, &stream.data, &stream.len);
     if (err < 0) return rpc_error;
   }
 
-  if (result) *result = response;
+  if (result) *result = stream;
 
   return 0;
 }

--- a/test/message.c
+++ b/test/message.c
@@ -66,9 +66,71 @@ test_response(void) {
   free(enc.buffer);
 }
 
+static void
+test_stream_data(void) {
+  uint8_t payload[] = {5, 6, 7, 8};
+
+  rpc_message_t msg = {0};
+  msg.type = rpc_stream;
+  msg.id = 3;
+  msg.stream = rpc_stream_data;
+  msg.data = payload;
+  msg.len = sizeof(payload);
+
+  compact_state_t enc = {0, 0, NULL};
+  assert(rpc_preencode_message(&enc, &msg) == 0);
+  enc.buffer = malloc(enc.end);
+  assert(rpc_encode_message(&enc, &msg) == 0);
+
+  compact_state_t dec = {0, enc.end, enc.buffer};
+  rpc_message_t out = {0};
+  assert(rpc_decode_message(&dec, &out) == 0);
+
+  assert(out.type == rpc_stream);
+  assert(out.id == 3);
+  assert(out.stream == rpc_stream_data);
+  assert(out.len == sizeof(payload));
+  assert(memcmp(out.data, payload, sizeof(payload)) == 0);
+
+  free(enc.buffer);
+}
+
+static void
+test_stream_error(void) {
+  rpc_message_t msg = {0};
+  msg.type = rpc_stream;
+  msg.id = 4;
+  msg.stream = rpc_stream_error;
+  msg.message = (utf8_string_view_t){(const utf8_t *) "boom", 4};
+  msg.code = (utf8_string_view_t){(const utf8_t *) "ERR", 3};
+  msg.status = 500;
+
+  compact_state_t enc = {0, 0, NULL};
+  assert(rpc_preencode_message(&enc, &msg) == 0);
+  enc.buffer = malloc(enc.end);
+  assert(rpc_encode_message(&enc, &msg) == 0);
+
+  compact_state_t dec = {0, enc.end, enc.buffer};
+  rpc_message_t out = {0};
+  assert(rpc_decode_message(&dec, &out) == 0);
+
+  assert(out.type == rpc_stream);
+  assert(out.id == 4);
+  assert(out.stream == rpc_stream_error);
+  assert(out.status == 500);
+  assert(out.message.len == 4);
+  assert(memcmp(out.message.data, "boom", 4) == 0);
+  assert(out.code.len == 3);
+  assert(memcmp(out.code.data, "ERR", 3) == 0);
+
+  free(enc.buffer);
+}
+
 int
 main(void) {
   test_request();
   test_response();
+  test_stream_data();
+  test_stream_error();
   return 0;
 }


### PR DESCRIPTION
rpc_decode__stream had two bugs (copy-paste from the response decoder):

1. It set the decoded type to rpc_response instead of rpc_stream.
2. It decoded the stream flags field twice, while the encoder writes it once. The second read consumed the next field (data length or error message), corrupting the flags and misaligning the rest of the parse.

Fixes both, renames the local from response to stream to match the encoder, and adds stream round-trip tests (data + error) that fail on the old code and pass on the new. This is the librpc PR B that unblocks hrpc-c streaming codegen.