### PR TITLE
rpc_client_t: stateful client runtime

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,7 +19,7 @@ target_sources(
   rpc
   INTERFACE
     include/rpc.h
-    include/client.h
+    include/rpc/client.h
   PRIVATE
     src/rpc.c
     src/client.c
@@ -76,7 +76,7 @@ install(TARGETS rpc_shared rpc_static)
 
 install(FILES include/rpc.h DESTINATION include)
 
-install(FILES include/client.h DESTINATION include)
+install(DIRECTORY include/rpc DESTINATION include)
 
 if(PROJECT_IS_TOP_LEVEL)
   enable_testing()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,8 +19,10 @@ target_sources(
   rpc
   INTERFACE
     include/rpc.h
+    include/client.h
   PRIVATE
     src/rpc.c
+    src/client.c
 )
 
 target_include_directories(
@@ -73,6 +75,8 @@ target_link_libraries(
 install(TARGETS rpc_shared rpc_static)
 
 install(FILES include/rpc.h DESTINATION include)
+
+install(FILES include/client.h DESTINATION include)
 
 if(PROJECT_IS_TOP_LEVEL)
   enable_testing()

--- a/include/client.h
+++ b/include/client.h
@@ -1,0 +1,74 @@
+#ifndef RPC_CLIENT_H
+#define RPC_CLIENT_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include <stddef.h>
+#include <stdint.h>
+
+#include "rpc.h"
+
+// Resolved reply, or a routed event/stream frame. The views in *msg (data,
+// message, code) point into the runtime's internal buffer and are valid ONLY
+// for the duration of the callback - copy out anything kept past it.
+typedef void (*rpc_client_cb)(void *data, const rpc_message_t *msg);
+
+typedef struct rpc_client_pending_s {
+  uint64_t id;
+  rpc_client_cb cb;
+  void *data;
+} rpc_client_pending_t;
+
+typedef struct rpc_client_s {
+  uint64_t next_id; // initialised to 1; next_id() returns then increments
+
+  rpc_client_pending_t *pending; // growable, linear scan, swap-remove
+  size_t pending_len;
+  size_t pending_cap;
+
+  uint8_t *buffer; // accumulation buffer for partial frames
+  size_t buffer_len;
+  size_t buffer_cap;
+
+  rpc_client_cb on_message; // fallthrough: events, stream frames, untracked
+  void *on_message_data;
+
+  uint8_t reading; // reentrancy guard for rpc_client_read
+} rpc_client_t;
+
+// client error codes (< 0), distinct from rpc_error / rpc_partial
+enum {
+  rpc_client_err_alloc = -10,
+  rpc_client_err_decode = -11,
+  rpc_client_err_reentrant = -12,
+};
+
+int
+rpc_client_init (rpc_client_t *client, rpc_client_cb on_message, void *data);
+
+void
+rpc_client_destroy (rpc_client_t *client);
+
+uint64_t
+rpc_client_next_id (rpc_client_t *client);
+
+// Safe to call from within a callback. Returns 0 or rpc_client_err_alloc.
+int
+rpc_client_track (rpc_client_t *client, uint64_t id, rpc_client_cb cb, void *data);
+
+// Remove a pending entry by id (idempotent). Safe from within a callback.
+int
+rpc_client_untrack (rpc_client_t *client, uint64_t id);
+
+// Feed inbound bytes. Decodes complete frames and routes them. Returns 0, or
+// rpc_client_err_* (< 0). MUST NOT be called from within a callback.
+int
+rpc_client_read (rpc_client_t *client, const uint8_t *buf, size_t len);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif // RPC_CLIENT_H

--- a/include/rpc/client.h
+++ b/include/rpc/client.h
@@ -5,6 +5,7 @@
 extern "C" {
 #endif
 
+#include <stdbool.h>
 #include <stddef.h>
 #include <stdint.h>
 
@@ -35,7 +36,7 @@ typedef struct rpc_client_s {
   rpc_client_cb on_message; // fallthrough: events, stream frames, untracked
   void *on_message_data;
 
-  uint8_t reading; // reentrancy guard for rpc_client_read
+  bool reading; // reentrancy guard for rpc_client_read
 } rpc_client_t;
 
 // client error codes (< 0), distinct from rpc_error / rpc_partial

--- a/include/rpc/client.h
+++ b/include/rpc/client.h
@@ -8,7 +8,7 @@ extern "C" {
 #include <stddef.h>
 #include <stdint.h>
 
-#include "rpc.h"
+#include <rpc.h>
 
 // Resolved reply, or a routed event/stream frame. The views in *msg (data,
 // message, code) point into the runtime's internal buffer and are valid ONLY

--- a/src/client.c
+++ b/src/client.c
@@ -53,7 +53,7 @@ rpc_client_untrack (rpc_client_t *client, uint64_t id) {
 
 // Resolve a pending one-shot reply. Returns 1 if it consumed the message.
 static int
-client__resolve (rpc_client_t *client, const rpc_message_t *msg) {
+rpc_client__resolve (rpc_client_t *client, const rpc_message_t *msg) {
   if (msg->type != rpc_response || msg->stream != 0) return 0;
   for (size_t i = 0; i < client->pending_len; i++) {
     if (client->pending[i].id == msg->id) {

--- a/src/client.c
+++ b/src/client.c
@@ -25,8 +25,55 @@ rpc_client_next_id (rpc_client_t *client) {
 }
 
 int
+rpc_client_track (rpc_client_t *client, uint64_t id, rpc_client_cb cb, void *data) {
+  if (client->pending_len == client->pending_cap) {
+    size_t cap = client->pending_cap ? client->pending_cap * 2 : 4;
+    rpc_client_pending_t *next = realloc(client->pending, cap * sizeof(*next));
+    if (next == NULL) return rpc_client_err_alloc;
+    client->pending = next;
+    client->pending_cap = cap;
+  }
+  client->pending[client->pending_len].id = id;
+  client->pending[client->pending_len].cb = cb;
+  client->pending[client->pending_len].data = data;
+  client->pending_len++;
+  return 0;
+}
+
+int
+rpc_client_untrack (rpc_client_t *client, uint64_t id) {
+  for (size_t i = 0; i < client->pending_len; i++) {
+    if (client->pending[i].id == id) {
+      client->pending[i] = client->pending[--client->pending_len];
+      return 0;
+    }
+  }
+  return 0;
+}
+
+// Resolve a pending one-shot reply. Returns 1 if it consumed the message.
+static int
+client__resolve (rpc_client_t *client, const rpc_message_t *msg) {
+  if (msg->type != rpc_response || msg->stream != 0) return 0;
+  for (size_t i = 0; i < client->pending_len; i++) {
+    if (client->pending[i].id == msg->id) {
+      // swap-remove before invoking, so the callback may track/untrack safely
+      rpc_client_pending_t entry = client->pending[i];
+      client->pending[i] = client->pending[--client->pending_len];
+      entry.cb(entry.data, msg);
+      return 1;
+    }
+  }
+  return 0;
+}
+
+int
 rpc_client_read (rpc_client_t *client, const uint8_t *buf, size_t len) {
   if (client->reading) return rpc_client_err_reentrant;
+  // The guard also keeps the accumulation buffer immutable during callbacks: a
+  // reentrant read (which could realloc the buffer) is refused, so the msg
+  // views handed to a callback stay valid. A future "allow reentrant read"
+  // change must not break this.
   client->reading = 1;
 
   if (len > 0) {
@@ -56,7 +103,9 @@ rpc_client_read (rpc_client_t *client, const uint8_t *buf, size_t len) {
       client->reading = 0;
       return rpc_client_err_decode;
     }
-    if (client->on_message) client->on_message(client->on_message_data, &msg);
+    if (!client__resolve(client, &msg)) {
+      if (client->on_message) client->on_message(client->on_message_data, &msg);
+    }
     start = state.start; // post-decode start is the consumed offset
   }
 

--- a/src/client.c
+++ b/src/client.c
@@ -23,3 +23,48 @@ uint64_t
 rpc_client_next_id (rpc_client_t *client) {
   return client->next_id++;
 }
+
+int
+rpc_client_read (rpc_client_t *client, const uint8_t *buf, size_t len) {
+  if (client->reading) return rpc_client_err_reentrant;
+  client->reading = 1;
+
+  if (len > 0) {
+    size_t need = client->buffer_len + len;
+    if (need > client->buffer_cap) {
+      size_t cap = client->buffer_cap ? client->buffer_cap : 64;
+      while (cap < need) cap *= 2;
+      uint8_t *next = realloc(client->buffer, cap);
+      if (next == NULL) {
+        client->reading = 0;
+        return rpc_client_err_alloc;
+      }
+      client->buffer = next;
+      client->buffer_cap = cap;
+    }
+    memcpy(client->buffer + client->buffer_len, buf, len);
+    client->buffer_len += len;
+  }
+
+  size_t start = 0;
+  while (start < client->buffer_len) {
+    compact_state_t state = {start, client->buffer_len, client->buffer};
+    rpc_message_t msg = {0};
+    int r = rpc_decode_message(&state, &msg);
+    if (r == rpc_partial) break;
+    if (r < 0) { // any other negative is a hard decode error (malformed frame)
+      client->reading = 0;
+      return rpc_client_err_decode;
+    }
+    if (client->on_message) client->on_message(client->on_message_data, &msg);
+    start = state.start; // post-decode start is the consumed offset
+  }
+
+  if (start > 0) {
+    memmove(client->buffer, client->buffer + start, client->buffer_len - start);
+    client->buffer_len -= start;
+  }
+
+  client->reading = 0;
+  return 0;
+}

--- a/src/client.c
+++ b/src/client.c
@@ -74,7 +74,7 @@ rpc_client_read (rpc_client_t *client, const uint8_t *buf, size_t len) {
   // reentrant read (which could realloc the buffer) is refused, so the msg
   // views handed to a callback stay valid. A future "allow reentrant read"
   // change must not break this.
-  client->reading = 1;
+  client->reading = true;
 
   if (len > 0) {
     size_t need = client->buffer_len + len;
@@ -83,7 +83,7 @@ rpc_client_read (rpc_client_t *client, const uint8_t *buf, size_t len) {
       while (cap < need) cap *= 2;
       uint8_t *next = realloc(client->buffer, cap);
       if (next == NULL) {
-        client->reading = 0;
+        client->reading = false;
         return rpc_client_err_alloc;
       }
       client->buffer = next;
@@ -100,7 +100,7 @@ rpc_client_read (rpc_client_t *client, const uint8_t *buf, size_t len) {
     int r = rpc_decode_message(&state, &msg);
     if (r == rpc_partial) break;
     if (r < 0) { // any other negative is a hard decode error (malformed frame)
-      client->reading = 0;
+      client->reading = false;
       return rpc_client_err_decode;
     }
     if (!rpc_client__resolve(client, &msg)) {
@@ -114,6 +114,6 @@ rpc_client_read (rpc_client_t *client, const uint8_t *buf, size_t len) {
     client->buffer_len -= start;
   }
 
-  client->reading = 0;
+  client->reading = false;
   return 0;
 }

--- a/src/client.c
+++ b/src/client.c
@@ -1,0 +1,25 @@
+#include <stdlib.h>
+#include <string.h>
+
+#include "../include/client.h"
+
+int
+rpc_client_init (rpc_client_t *client, rpc_client_cb on_message, void *data) {
+  memset(client, 0, sizeof(*client));
+  client->next_id = 1;
+  client->on_message = on_message;
+  client->on_message_data = data;
+  return 0;
+}
+
+void
+rpc_client_destroy (rpc_client_t *client) {
+  free(client->pending);
+  free(client->buffer);
+  memset(client, 0, sizeof(*client));
+}
+
+uint64_t
+rpc_client_next_id (rpc_client_t *client) {
+  return client->next_id++;
+}

--- a/src/client.c
+++ b/src/client.c
@@ -1,7 +1,7 @@
 #include <stdlib.h>
 #include <string.h>
 
-#include "../include/client.h"
+#include "../include/rpc/client.h"
 
 int
 rpc_client_init (rpc_client_t *client, rpc_client_cb on_message, void *data) {
@@ -103,7 +103,7 @@ rpc_client_read (rpc_client_t *client, const uint8_t *buf, size_t len) {
       client->reading = 0;
       return rpc_client_err_decode;
     }
-    if (!client__resolve(client, &msg)) {
+    if (!rpc_client__resolve(client, &msg)) {
       if (client->on_message) client->on_message(client->on_message_data, &msg);
     }
     start = state.start; // post-decode start is the consumed offset

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,5 +1,6 @@
 list(APPEND tests
   message
+  client
 )
 
 foreach(test IN LISTS tests)

--- a/test/client.c
+++ b/test/client.c
@@ -31,9 +31,173 @@ test_double_destroy (void) {
   rpc_client_destroy(&client); // safe: pointers are NULL after the first destroy
 }
 
+// Encode an rpc_message into a fresh malloc'd buffer (caller frees).
+static uint8_t *
+encode_message (const rpc_message_t *msg, size_t *len) {
+  compact_state_t enc = {0, 0, NULL};
+  assert(rpc_preencode_message(&enc, msg) == 0);
+  enc.buffer = malloc(enc.end);
+  assert(rpc_encode_message(&enc, msg) == 0);
+  *len = enc.end;
+  return enc.buffer;
+}
+
+typedef struct {
+  int count;
+  uint64_t last_id;
+  uint64_t last_type;
+} recorder_t;
+
+static void
+on_fallthrough (void *data, const rpc_message_t *msg) {
+  recorder_t *r = data;
+  r->count++;
+  r->last_id = msg->id;
+  r->last_type = msg->type;
+}
+
+// Build a unary response frame (type 2, stream 0) carrying `payload`.
+static uint8_t *
+response_frame (uint64_t id, uint8_t *payload, size_t payload_len, size_t *len) {
+  rpc_message_t msg = {0};
+  msg.type = rpc_response;
+  msg.id = id;
+  msg.error = false;
+  msg.stream = 0;
+  msg.data = payload;
+  msg.len = payload_len;
+  return encode_message(&msg, len);
+}
+
+static void
+test_read_routes_to_fallthrough (void) {
+  recorder_t rec = {0};
+  rpc_client_t client;
+  rpc_client_init(&client, on_fallthrough, &rec);
+
+  uint8_t payload[] = {1, 2, 3};
+  size_t len;
+  uint8_t *frame = response_frame(7, payload, sizeof(payload), &len);
+
+  assert(rpc_client_read(&client, frame, len) == 0);
+  assert(rec.count == 1);
+  assert(rec.last_id == 7);
+  assert(rec.last_type == rpc_response);
+
+  free(frame);
+  rpc_client_destroy(&client);
+}
+
+static void
+test_read_partial_frame (void) {
+  recorder_t rec = {0};
+  rpc_client_t client;
+  rpc_client_init(&client, on_fallthrough, &rec);
+
+  uint8_t payload[] = {9, 8, 7, 6};
+  size_t len;
+  uint8_t *frame = response_frame(3, payload, sizeof(payload), &len);
+
+  assert(rpc_client_read(&client, frame, len - 2) == 0);
+  assert(rec.count == 0);
+  assert(rpc_client_read(&client, frame + len - 2, 2) == 0);
+  assert(rec.count == 1);
+  assert(rec.last_id == 3);
+
+  free(frame);
+  rpc_client_destroy(&client);
+}
+
+static void
+test_read_multiple_frames (void) {
+  recorder_t rec = {0};
+  rpc_client_t client;
+  rpc_client_init(&client, on_fallthrough, &rec);
+
+  uint8_t p1[] = {1};
+  uint8_t p2[] = {2};
+  size_t l1, l2;
+  uint8_t *f1 = response_frame(1, p1, sizeof(p1), &l1);
+  uint8_t *f2 = response_frame(2, p2, sizeof(p2), &l2);
+
+  uint8_t *both = malloc(l1 + l2);
+  memcpy(both, f1, l1);
+  memcpy(both + l1, f2, l2);
+
+  assert(rpc_client_read(&client, both, l1 + l2) == 0);
+  assert(rec.count == 2);
+  assert(rec.last_id == 2);
+
+  free(f1);
+  free(f2);
+  free(both);
+  rpc_client_destroy(&client);
+}
+
+static void
+on_reenter (void *data, const rpc_message_t *msg) {
+  rpc_client_t *client = data;
+  (void) msg;
+  assert(rpc_client_read(client, (const uint8_t *) "", 0) == rpc_client_err_reentrant);
+}
+
+static void
+test_read_reentrancy_guard (void) {
+  rpc_client_t client;
+  rpc_client_init(&client, on_reenter, &client);
+
+  uint8_t payload[] = {1};
+  size_t len;
+  uint8_t *frame = response_frame(5, payload, sizeof(payload), &len);
+
+  assert(rpc_client_read(&client, frame, len) == 0);
+
+  free(frame);
+  rpc_client_destroy(&client);
+}
+
+static void
+test_read_malformed (void) {
+  recorder_t rec = {0};
+  rpc_client_t client;
+  rpc_client_init(&client, on_fallthrough, &rec);
+
+  uint8_t payload[] = {1};
+  size_t len;
+  uint8_t *frame = response_frame(1, payload, sizeof(payload), &len);
+  // The frame length is a fixed-width 4-byte uint32, so byte 4 is the type
+  // varint; 0x7f decodes to 127, an unknown type -> rpc_error -> err_decode.
+  frame[4] = 0x7f;
+
+  assert(rpc_client_read(&client, frame, len) == rpc_client_err_decode);
+
+  free(frame);
+  rpc_client_destroy(&client);
+}
+
+static void
+test_read_empty (void) {
+  recorder_t rec = {0};
+  rpc_client_t client;
+  rpc_client_init(&client, on_fallthrough, &rec);
+
+  // a zero-length read is a no-op: returns 0, fires nothing, state unchanged
+  assert(rpc_client_read(&client, NULL, 0) == 0);
+  assert(rec.count == 0);
+  assert(client.buffer_len == 0);
+
+  rpc_client_destroy(&client);
+}
+
 int
 main (void) {
   test_next_id();
   test_double_destroy();
+  test_read_routes_to_fallthrough();
+  test_read_partial_frame();
+  test_read_multiple_frames();
+  test_read_reentrancy_guard();
+  test_read_malformed();
+  test_read_empty();
   return 0;
 }

--- a/test/client.c
+++ b/test/client.c
@@ -189,6 +189,198 @@ test_read_empty (void) {
   rpc_client_destroy(&client);
 }
 
+typedef struct {
+  int count;
+  uint64_t last_id;
+  bool last_error;
+  int64_t last_status;
+} reply_t;
+
+static void
+on_reply (void *data, const rpc_message_t *msg) {
+  reply_t *r = data;
+  r->count++;
+  r->last_id = msg->id;
+  r->last_error = msg->error;
+  if (msg->error) r->last_status = msg->status;
+}
+
+static uint8_t *
+error_frame (uint64_t id, size_t *len) {
+  rpc_message_t msg = {0};
+  msg.type = rpc_response;
+  msg.id = id;
+  msg.error = true;
+  msg.stream = 0;
+  msg.message = (utf8_string_view_t){(const utf8_t *) "boom", 4};
+  msg.code = (utf8_string_view_t){(const utf8_t *) "ERR", 3};
+  msg.status = 500;
+  return encode_message(&msg, len);
+}
+
+static void
+test_track_resolves_once (void) {
+  recorder_t fall = {0};
+  reply_t reply = {0};
+  rpc_client_t client;
+  rpc_client_init(&client, on_fallthrough, &fall);
+
+  assert(rpc_client_track(&client, 7, on_reply, &reply) == 0);
+
+  uint8_t payload[] = {1, 2, 3};
+  size_t len;
+  uint8_t *frame = response_frame(7, payload, sizeof(payload), &len);
+
+  // first response resolves the pending callback, not the fallthrough
+  assert(rpc_client_read(&client, frame, len) == 0);
+  assert(reply.count == 1);
+  assert(reply.last_id == 7);
+  assert(reply.last_error == false);
+  assert(fall.count == 0);
+
+  // a second response for the same id falls through (entry was removed)
+  assert(rpc_client_read(&client, frame, len) == 0);
+  assert(reply.count == 1);
+  assert(fall.count == 1);
+
+  free(frame);
+  rpc_client_destroy(&client);
+}
+
+static void
+test_error_reply_resolves (void) {
+  reply_t reply = {0};
+  rpc_client_t client;
+  rpc_client_init(&client, noop, NULL);
+
+  rpc_client_track(&client, 4, on_reply, &reply);
+
+  size_t len;
+  uint8_t *frame = error_frame(4, &len);
+
+  assert(rpc_client_read(&client, frame, len) == 0);
+  assert(reply.count == 1);
+  assert(reply.last_id == 4);
+  assert(reply.last_error == true);
+  assert(reply.last_status == 500);
+
+  free(frame);
+  rpc_client_destroy(&client);
+}
+
+static void
+test_untrack (void) {
+  recorder_t fall = {0};
+  reply_t reply = {0};
+  rpc_client_t client;
+  rpc_client_init(&client, on_fallthrough, &fall);
+
+  rpc_client_track(&client, 9, on_reply, &reply);
+  assert(rpc_client_untrack(&client, 9) == 0);
+  assert(rpc_client_untrack(&client, 999) == 0); // idempotent: absent id
+
+  uint8_t payload[] = {1};
+  size_t len;
+  uint8_t *frame = response_frame(9, payload, sizeof(payload), &len);
+
+  // untracked: routes to fallthrough, pending cb never fires
+  assert(rpc_client_read(&client, frame, len) == 0);
+  assert(reply.count == 0);
+  assert(fall.count == 1);
+
+  free(frame);
+  rpc_client_destroy(&client);
+}
+
+static void
+test_event_falls_through_even_when_tracking (void) {
+  recorder_t fall = {0};
+  reply_t reply = {0};
+  rpc_client_t client;
+  rpc_client_init(&client, on_fallthrough, &fall);
+
+  rpc_client_track(&client, 0, on_reply, &reply); // contrived: id 0
+
+  // an event is a request frame (type 1) with id 0 - resolution is response-
+  // only, so it must NOT resolve a pending entry; it goes to the fallthrough
+  rpc_message_t ev = {0};
+  ev.type = rpc_request;
+  ev.id = 0;
+  ev.command = 1;
+  ev.stream = 0;
+  uint8_t epayload[] = {42};
+  ev.data = epayload;
+  ev.len = sizeof(epayload);
+  size_t len;
+  uint8_t *frame = encode_message(&ev, &len);
+
+  assert(rpc_client_read(&client, frame, len) == 0);
+  assert(reply.count == 0);
+  assert(fall.count == 1);
+  assert(fall.last_type == rpc_request);
+
+  free(frame);
+  rpc_client_destroy(&client);
+}
+
+static void
+test_track_grows_past_cap (void) {
+  reply_t replies[8] = {0};
+  rpc_client_t client;
+  rpc_client_init(&client, noop, NULL);
+
+  // more than the initial cap (4) to exercise the pending realloc growth path
+  for (uint64_t i = 1; i <= 8; i++) {
+    assert(rpc_client_track(&client, i, on_reply, &replies[i - 1]) == 0);
+  }
+  for (uint64_t i = 1; i <= 8; i++) {
+    uint8_t payload[] = {1};
+    size_t len;
+    uint8_t *frame = response_frame(i, payload, sizeof(payload), &len);
+    assert(rpc_client_read(&client, frame, len) == 0);
+    free(frame);
+  }
+  for (int i = 0; i < 8; i++) assert(replies[i].count == 1);
+
+  rpc_client_destroy(&client);
+}
+
+typedef struct {
+  rpc_client_t *client;
+  int count;
+} tracker_ctx_t;
+
+// a resolution callback that registers follow-up requests, forcing a pending
+// realloc mid-callback - must not corrupt the in-flight resolution (the entry
+// was copied to the stack and swap-removed before this ran)
+static void
+on_reply_then_track (void *data, const rpc_message_t *msg) {
+  (void) msg;
+  tracker_ctx_t *ctx = data;
+  ctx->count++;
+  for (uint64_t i = 100; i < 110; i++) {
+    assert(rpc_client_track(ctx->client, i, noop, NULL) == 0);
+  }
+}
+
+static void
+test_callback_tracks_during_resolution (void) {
+  rpc_client_t client;
+  rpc_client_init(&client, noop, NULL);
+  tracker_ctx_t ctx = {&client, 0};
+
+  rpc_client_track(&client, 7, on_reply_then_track, &ctx);
+
+  uint8_t payload[] = {1};
+  size_t len;
+  uint8_t *frame = response_frame(7, payload, sizeof(payload), &len);
+  assert(rpc_client_read(&client, frame, len) == 0);
+  assert(ctx.count == 1); // resolved exactly once despite the realloc
+
+  free(frame);
+  rpc_client_destroy(&client);
+}
+
 int
 main (void) {
   test_next_id();
@@ -199,5 +391,11 @@ main (void) {
   test_read_reentrancy_guard();
   test_read_malformed();
   test_read_empty();
+  test_track_resolves_once();
+  test_error_reply_resolves();
+  test_untrack();
+  test_event_falls_through_even_when_tracking();
+  test_track_grows_past_cap();
+  test_callback_tracks_during_resolution();
   return 0;
 }

--- a/test/client.c
+++ b/test/client.c
@@ -1,0 +1,39 @@
+#include <assert.h>
+#include <stddef.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "../include/client.h"
+
+static void
+noop (void *data, const rpc_message_t *msg) {
+  (void) data;
+  (void) msg;
+}
+
+static void
+test_next_id (void) {
+  rpc_client_t client;
+  assert(rpc_client_init(&client, noop, NULL) == 0);
+
+  assert(rpc_client_next_id(&client) == 1);
+  assert(rpc_client_next_id(&client) == 2);
+  assert(rpc_client_next_id(&client) == 3);
+
+  rpc_client_destroy(&client);
+}
+
+static void
+test_double_destroy (void) {
+  rpc_client_t client;
+  rpc_client_init(&client, noop, NULL);
+  rpc_client_destroy(&client);
+  rpc_client_destroy(&client); // safe: pointers are NULL after the first destroy
+}
+
+int
+main (void) {
+  test_next_id();
+  test_double_destroy();
+  return 0;
+}

--- a/test/client.c
+++ b/test/client.c
@@ -3,7 +3,7 @@
 #include <stdlib.h>
 #include <string.h>
 
-#include "../include/client.h"
+#include "../include/rpc/client.h"
 
 static void
 noop (void *data, const rpc_message_t *msg) {


### PR DESCRIPTION
Adds a sans-io, schema-agnostic client runtime to librpc (SPEC amendment G / lib C) that turns the wire codec into something a consumer can drive.

API: rpc_client_init/destroy, rpc_client_next_id (monotonic from 1), rpc_client_track / rpc_client_untrack (pending one-shot reply callbacks), rpc_client_read (feed arbitrary inbound bytes). read accumulates into an internal buffer, decodes complete frames, and routes each: a tracked unary/request-stream terminal reply (rpc_response, stream 0 - success or error) resolves its one-shot callback; everything else (events, stream frames, type-2 stream-OPEN, untracked) goes to a fallthrough handler. Reentrancy-guarded; callback message views are valid only during the callback; the consumer correlates ids to decoders.

New include/client.h + src/client.c compiled into the rpc library (separate from the rpc.c wire codec); pure-C tests in test/client.c (14 cases: framing/partial/multiple, reentrancy, malformed, resolution, error reply, untrack, pending growth, callback-tracks-during-resolution). Dependency-free (no libuv); the optional libuv adapter is deferred.