### PR TITLE
Document status field as the canonical wire errno

### DIFF
--- a/include/rpc.h
+++ b/include/rpc.h
@@ -67,6 +67,8 @@ struct rpc_message_s {
     struct {
       utf8_string_view_t message;
       utf8_string_view_t code;
+      // Canonical wire field is `errno` (JS/Swift; see hrpc-test WIRE.md); named
+      // `status` here because `errno` is a reserved macro in C (<errno.h>).
       int64_t status;
     };
   };


### PR DESCRIPTION
The error message's third field is the canonical wire `errno` (JS `bare-rpc` and `bare-rpc-swift` both name it `errno`; see `hrpc-test`'s WIRE.md). C names it `status` instead because `errno` is a reserved macro in C (`<errno.h>`, reachable here via `uv.h`) - a struct field named `errno` fails to compile. Comment-only; documents the mapping so the name difference isn't mistaken for a wire divergence.